### PR TITLE
fix(package): remove unnecessary `prepare` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "default_index.ejs"
   ],
   "scripts": {
-    "prepare": "npm run test",
     "pretest": "semistandard",
     "build-examples": "node examples/build-examples.js",
     "test": "jasmine",


### PR DESCRIPTION
this PR is intended to demonstrate a temporary resolution to #16 (and also includes #13 )

Install it from GitHub as so 
```shell
# you may want to clear cache
$ yarn add html-webpack-plugin@https://github.com/thescientist13/html-webpack-plugin.git#25b840b765087751403e896e8cc15c3f59f777ae --dev
```

This worked for me locally and also got my CircleCI build back to passing 🎉 
https://circleci.com/gh/ProvidenceGeeks/website-frontend/317